### PR TITLE
Fix #5

### DIFF
--- a/documentation/ingest-wait-for-completion.md
+++ b/documentation/ingest-wait-for-completion.md
@@ -1,5 +1,10 @@
 # Wait for Ingestion to Complete
-After deploying the ingestion Terraform resources you will need to wait for the ingestion to complete before being able to search the documents.
+After deploying the ingestion Terraform resources you will need to wait for the ingestion to complete before being able to search the documents. Check the [Amazon Elastic Container Service console](https://console.aws.amazon.com/ecs) to see when the task completes, or use below AWS CLI commands to wait for the task to complete.
+
+## Wait in AWS Console
+Go to the Tasks page of your Amazon ECS Cluster that the infrastructure stack deployed. The default name of the cluster is *NLPSearchECSCluster*. In Tasks list look for the task that has `ingestion-job` as the Task definition. Wait until the status of the `ingestion-job` task changes from *Running* to *Stopped*.
+
+## Use AWS CLI to wait
 1. Navigate to the infrastructure directory `cd ~/semantic-search-aws-docs/infrastructure`.
 1. Run `ECS_CLUSTER_ARN=$(terraform output --raw ecs_cluster_arn)` to get the ARN of your Amazon ECS cluster.
 2. Run `TASK_ARN=$(aws ecs list-tasks --family ingestion-job --region $REGION --cluster $ECS_CLUSTER_ARN --output text --query 'taskArns[0]')` to get the ARN of the ECS task that is ingesting the documents.

--- a/documentation/ingest-wait-for-completion.md
+++ b/documentation/ingest-wait-for-completion.md
@@ -2,6 +2,6 @@
 After deploying the ingestion Terraform resources you will need to wait for the ingestion to complete before being able to search the documents.
 1. Navigate to the infrastructure directory `cd ~/semantic-search-aws-docs/infrastructure`.
 1. Run `ECS_CLUSTER_ARN=$(terraform output --raw ecs_cluster_arn)` to get the ARN of your Amazon ECS cluster.
-2. Run `TASK_ARN=$(aws ecs list-tasks --family ingestion-job --region $REGION --cluster $ECS_CLUSTER_ARN --query 'taskArns[0]')` to get the ARN of the ECS task that is ingesting the documents.
+2. Run `TASK_ARN=$(aws ecs list-tasks --family ingestion-job --region $REGION --cluster $ECS_CLUSTER_ARN --output text --query 'taskArns[0]')` to get the ARN of the ECS task that is ingesting the documents.
 3. Run `aws ecs wait tasks-stopped --region $REGION --cluster $ECS_CLUSTER_ARN --tasks $TASK_ARN` to wait until the ingestion of the documents completes. When the command exits with _Waiter TasksStopped failed: Max attempts exceeded_ as the message run the command again. Once the command exits without any output then the ingestion job completed.
 4. After the ingestion completes run `terraform output loadbalancer_url` to get the URL for the semantic search frontend.

--- a/ingestion/awsdocs/requirements.txt
+++ b/ingestion/awsdocs/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4>=4.11.1
 opensearch-py>=2.0.0
 farm-haystack[opensearch,preprocessing,file-conversion]
 rfc3986-validator
+pydantic==1.*

--- a/ingestion/awsdocs/scripts/clone_awsdocs.sh
+++ b/ingestion/awsdocs/scripts/clone_awsdocs.sh
@@ -28,7 +28,12 @@ echo "Page: $c / $numPages"
    do
       if [[ "$line" == *$REPO* ]] || [[ "$line" == full ]]  ;
       then
-          git clone $line || true
+          echo "Found: $line"
+          if ! git clone -b main $line; then
+            if ! git clone -b master $line; then
+               git clone $line || true
+            fi
+          fi
       fi
    done
 done


### PR DESCRIPTION
*Issue #, if available:* #5

*Description of changes:*
* Update wait for ingestion documentation to add instructions for waiting in the AWS Console.
* Update wait for ingestion documentation to remove quotation marks from TASK_ARN which caused InvalidParameterException.
* Ingestion: pin pydantic to version v1 because pydantic v2 is not compatible with Haystack until Haystack v2 release. See also https://github.com/deepset-ai/haystack/issues/5304.
* Ingestion AWS Documentation from GitHub try cloning main or master branch because default `archived` branch does not contain documents. Related to https://aws.amazon.com/blogs/aws/retiring-the-aws-documentation-on-github/.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
